### PR TITLE
Add character data tools

### DIFF
--- a/Character Foundation/Scripts/CharacterData.cs
+++ b/Character Foundation/Scripts/CharacterData.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "CharacterData", menuName = "Sinclair/Character Data")]
+public class CharacterData : ScriptableObject
+{
+    public string characterName;
+    public int level;
+    public int maxHP;
+    public int maxMP;
+    public int strength;
+    public int defense;
+    public int agility;
+}

--- a/Sinclair-Tools/CharacterDataEditorWindow.cs
+++ b/Sinclair-Tools/CharacterDataEditorWindow.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using UnityEditor;
+
+public class CharacterDataEditorWindow : EditorWindow
+{
+    private CharacterData data;
+
+    [MenuItem("Window/Sinclair Tools/Character Data Editor")]
+    public static void ShowWindow()
+    {
+        GetWindow<CharacterDataEditorWindow>(false, "Character Data Editor");
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("Character Data", EditorStyles.boldLabel);
+
+        data = (CharacterData)EditorGUILayout.ObjectField("Data", data, typeof(CharacterData), false);
+        if (data == null)
+        {
+            EditorGUILayout.HelpBox("Select or create a Character Data asset.", MessageType.Info);
+            if (GUILayout.Button("Create New"))
+            {
+                CreateNewData();
+            }
+            return;
+        }
+
+        EditorGUILayout.Space();
+        data.characterName = EditorGUILayout.TextField("Name", data.characterName);
+        data.level = EditorGUILayout.IntField("Level", data.level);
+        data.maxHP = EditorGUILayout.IntField("Max HP", data.maxHP);
+        data.maxMP = EditorGUILayout.IntField("Max MP", data.maxMP);
+        data.strength = EditorGUILayout.IntField("Strength", data.strength);
+        data.defense = EditorGUILayout.IntField("Defense", data.defense);
+        data.agility = EditorGUILayout.IntField("Agility", data.agility);
+
+        if (GUI.changed)
+        {
+            EditorUtility.SetDirty(data);
+        }
+    }
+
+    private void CreateNewData()
+    {
+        data = ScriptableObject.CreateInstance<CharacterData>();
+        string path = EditorUtility.SaveFilePanelInProject("Save Character Data", "NewCharacterData", "asset", "Specify where to save the asset.");
+        if (!string.IsNullOrEmpty(path))
+        {
+            AssetDatabase.CreateAsset(data, path);
+            AssetDatabase.SaveAssets();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `CharacterData` scriptable object for storing RPG stats
- add `CharacterDataEditorWindow` to create and edit these assets in Unity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408ab006388328ab964c72fc9c1bcf