### PR TITLE
Add inventory and item demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ for several interior locations:
 - **Haphazard Helstien's H-Armory** next to **Hephaestus Café** prefab.
 - **Hephaestus Café** restaurant prefab with space for TV monitors.
 - **Samson's Office** – a beach-themed office prefab.
+- **Tutorial Fountain** demonstrating a `BattleActionEvent` that uses the
+  "Water Bottle" item when triggered.
 
 Open the `Olympus` scene from the Unity editor and use the doors placed around
 the main street to access each interior area. The interiors are simple prefabs

--- a/Scripts/GameSystems/BattleActionEvent.cs
+++ b/Scripts/GameSystems/BattleActionEvent.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Environment-triggered event that performs an item action on a target.
+/// </summary>
+public class BattleActionEvent : MonoBehaviour
+{
+    public ConsumableItem item;
+    public CharacterData target;
+
+    /// <summary>
+    /// Executes the event using the provided battle manager.
+    /// </summary>
+    public void Trigger(BattleManager manager)
+    {
+        if (manager == null || item == null || target == null)
+        {
+            return;
+        }
+
+        BattleCharacter character = manager.FindCharacter(target);
+        if (character != null)
+        {
+            manager.UseItem(character, item, character);
+        }
+    }
+}

--- a/Scripts/GameSystems/BattleManager.cs
+++ b/Scripts/GameSystems/BattleManager.cs
@@ -10,6 +10,8 @@ public class BattleManager : MonoBehaviour
 {
     public List<CharacterData> playerCharacters = new List<CharacterData>();
     public List<CharacterData> enemyCharacters = new List<CharacterData>();
+    public InventoryManager inventory; // Tracks consumable items
+    public ConsumableItem defaultItem;  // Item used for demo actions
 
     private readonly List<BattleCharacter> turnQueue = new List<BattleCharacter>();
     private int currentTurnIndex;
@@ -57,11 +59,19 @@ public class BattleManager : MonoBehaviour
             yield break;
         }
 
-        // Simple attack using character strength and defense values
-        int damage = Mathf.Max(1, character.data.strength - target.data.defense);
-        target.currentHP -= damage;
+        // Demonstration of using an item when below half HP
+        if (character.isPlayer && defaultItem != null && inventory != null && character.currentHP <= character.data.maxHP / 2 && inventory.GetQuantity(defaultItem) > 0)
+        {
+            UseItem(character, defaultItem, character);
+        }
+        else
+        {
+            // Simple attack using character strength and defense values
+            int damage = Mathf.Max(1, character.data.strength - target.data.defense);
+            target.currentHP -= damage;
 
-        Debug.Log($"{character.data.characterName} attacks {target.data.characterName} for {damage} damage!");
+            Debug.Log($"{character.data.characterName} attacks {target.data.characterName} for {damage} damage!");
+        }
 
         yield return new WaitForSeconds(1f);
     }
@@ -90,6 +100,33 @@ public class BattleManager : MonoBehaviour
             }
         }
         return list;
+    }
+
+    /// <summary>
+    /// Finds the runtime battle character associated with the given data.
+    /// </summary>
+    public BattleCharacter FindCharacter(CharacterData data)
+    {
+        foreach (BattleCharacter c in turnQueue)
+        {
+            if (c.data == data)
+            {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Uses a consumable item on the target.
+    /// </summary>
+    public void UseItem(BattleCharacter user, ConsumableItem item, BattleCharacter target)
+    {
+        if (inventory != null && user != null)
+        {
+            inventory.UseItem(item, target);
+            Debug.Log($"{user.data.characterName} uses {item.itemName} on {target.data.characterName}.");
+        }
     }
 }
 

--- a/Scripts/GameSystems/InventoryManager.cs
+++ b/Scripts/GameSystems/InventoryManager.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Tracks consumable items for the player party.
+/// </summary>
+public class InventoryManager : MonoBehaviour
+{
+    private readonly Dictionary<ConsumableItem, int> items = new Dictionary<ConsumableItem, int>();
+
+    /// <summary>
+    /// Adds a quantity of an item to the inventory.
+    /// </summary>
+    public void AddItem(ConsumableItem item, int amount = 1)
+    {
+        if (item == null)
+        {
+            return;
+        }
+
+        if (items.ContainsKey(item))
+        {
+            items[item] += amount;
+        }
+        else
+        {
+            items[item] = amount;
+        }
+    }
+
+    /// <summary>
+    /// Uses an item on a target character, applying its effect.
+    /// </summary>
+    public bool UseItem(ConsumableItem item, BattleCharacter target)
+    {
+        if (item == null || !items.ContainsKey(item) || items[item] <= 0)
+        {
+            return false;
+        }
+
+        items[item]--;
+        item.Apply(target);
+        return true;
+    }
+
+    /// <summary>
+    /// Returns how many of the given item the player has.
+    /// </summary>
+    public int GetQuantity(ConsumableItem item)
+    {
+        return items.TryGetValue(item, out int count) ? count : 0;
+    }
+}

--- a/Scripts/Items/ConsumableItem.cs
+++ b/Scripts/Items/ConsumableItem.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+/// <summary>
+/// Base class for consumable items that can affect a battle character.
+/// </summary>
+public class ConsumableItem : ScriptableObject
+{
+    public string itemName;
+    public string description;
+    public int healAmount;
+
+    /// <summary>
+    /// Apply this item's effect to the target character.
+    /// </summary>
+    public virtual void Apply(BattleCharacter target)
+    {
+        if (target != null)
+        {
+            target.currentHP = Mathf.Min(target.data.maxHP, target.currentHP + healAmount);
+            Debug.Log($"{itemName} heals {target.data.characterName} for {healAmount} HP.");
+        }
+    }
+}

--- a/Scripts/Items/WaterBottle.cs
+++ b/Scripts/Items/WaterBottle.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple consumable that restores a small amount of HP.
+/// </summary>
+[CreateAssetMenu(fileName = "WaterBottle", menuName = "Sinclair/Items/Water Bottle")]
+public class WaterBottle : ConsumableItem
+{
+    private void Reset()
+    {
+        itemName = "Water Bottle";
+        description = "Restores a small amount of HP.";
+        healAmount = 10;
+    }
+}


### PR DESCRIPTION
## Summary
- track consumables with `InventoryManager`
- create item ScriptableObject classes for consumables and `WaterBottle`
- allow item usage in `BattleManager`
- add `BattleActionEvent` for environment-triggered actions
- document fountain tutorial object in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68582a7860748328adb06f9173d04bf7