### PR TITLE
Add quest and lecture systems

### DIFF
--- a/Assets/Lectures/ElijahEthicsLecture.asset
+++ b/Assets/Lectures/ElijahEthicsLecture.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400010
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ElijahEthicsLecture
+  m_EditorClassIdentifier: 
+  lectureTitle: "Elijah's Ethics Lecture"
+  description: "A morning lecture from Elijah that slightly sharpens the mind."
+  hpBonus: 0
+  mpBonus: 5
+  strengthBonus: 0
+  defenseBonus: 0
+  agilityBonus: 1

--- a/Assets/Lectures/ForgeSafetyTraining.asset
+++ b/Assets/Lectures/ForgeSafetyTraining.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ForgeSafetyTraining
+  m_EditorClassIdentifier: 
+  lectureTitle: "Forge Safety Training"
+  description: "Ferris explains the dangers of the forge, toughening participants."
+  hpBonus: 0
+  mpBonus: 0
+  strengthBonus: 0
+  defenseBonus: 2
+  agilityBonus: 0

--- a/Assets/Quests/HelpReichLieutenant.asset
+++ b/Assets/Quests/HelpReichLieutenant.asset
@@ -1,0 +1,13 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HelpReichLieutenant
+  m_EditorClassIdentifier: 
+  questName: "Help Reich's Lieutenant"
+  description: "Complete tasks around D\u00farnir's Pass for Reich's lieutenant."
+  isMainQuest: 0

--- a/Assets/Quests/PrepareWarSimulator.asset
+++ b/Assets/Quests/PrepareWarSimulator.asset
@@ -1,0 +1,13 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PrepareWarSimulator
+  m_EditorClassIdentifier: 
+  questName: "Prepare for the War Simulator"
+  description: "Explore Olympus and attend class before the War Simulator."
+  isMainQuest: 1

--- a/Scripts/GameSystems/LectureDefinition.cs
+++ b/Scripts/GameSystems/LectureDefinition.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+/// <summary>
+/// Data for a lecture that can grant stat bonuses.
+/// </summary>
+[CreateAssetMenu(fileName = "LectureDefinition", menuName = "Sinclair/Lecture Definition")]
+public class LectureDefinition : ScriptableObject
+{
+    public string lectureTitle;
+    public string description;
+    public int hpBonus;
+    public int mpBonus;
+    public int strengthBonus;
+    public int defenseBonus;
+    public int agilityBonus;
+}

--- a/Scripts/GameSystems/LectureEvent.cs
+++ b/Scripts/GameSystems/LectureEvent.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Event that applies lecture stat bonuses to a character.
+/// </summary>
+public class LectureEvent : MonoBehaviour
+{
+    public CharacterData target;
+    public LectureDefinition lecture;
+
+    /// <summary>
+    /// Applies the lecture bonuses to the target character.
+    /// </summary>
+    public void Trigger()
+    {
+        if (target == null || lecture == null)
+        {
+            return;
+        }
+
+        target.maxHP += lecture.hpBonus;
+        target.maxMP += lecture.mpBonus;
+        target.strength += lecture.strengthBonus;
+        target.defense += lecture.defenseBonus;
+        target.agility += lecture.agilityBonus;
+
+        Debug.Log($"{target.characterName} attended {lecture.lectureTitle} and gained stat bonuses.");
+    }
+}

--- a/Scripts/GameSystems/QuestDefinition.cs
+++ b/Scripts/GameSystems/QuestDefinition.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Data describing a quest or side mission.
+/// </summary>
+[CreateAssetMenu(fileName = "QuestDefinition", menuName = "Sinclair/Quest Definition")]
+public class QuestDefinition : ScriptableObject
+{
+    public string questName;
+    public string description;
+    public bool isMainQuest;
+}

--- a/Scripts/GameSystems/QuestManager.cs
+++ b/Scripts/GameSystems/QuestManager.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Tracks active and completed quests for the player.
+/// </summary>
+public class QuestManager : MonoBehaviour
+{
+    public List<QuestDefinition> activeQuests = new List<QuestDefinition>();
+    public List<QuestDefinition> completedQuests = new List<QuestDefinition>();
+
+    /// <summary>
+    /// Adds a new quest if it isn't already active or completed.
+    /// </summary>
+    public void AddQuest(QuestDefinition quest)
+    {
+        if (quest == null || activeQuests.Contains(quest) || completedQuests.Contains(quest))
+        {
+            return;
+        }
+
+        activeQuests.Add(quest);
+    }
+
+    /// <summary>
+    /// Marks a quest as completed and removes it from the active list.
+    /// </summary>
+    public void CompleteQuest(QuestDefinition quest)
+    {
+        if (quest == null)
+        {
+            return;
+        }
+
+        if (activeQuests.Remove(quest))
+        {
+            completedQuests.Add(quest);
+            Debug.Log($"Quest completed: {quest.questName}");
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the quest is currently active.
+    /// </summary>
+    public bool IsQuestActive(QuestDefinition quest)
+    {
+        return activeQuests.Contains(quest);
+    }
+
+    /// <summary>
+    /// Returns true if the quest has already been completed.
+    /// </summary>
+    public bool IsQuestCompleted(QuestDefinition quest)
+    {
+        return completedQuests.Contains(quest);
+    }
+}


### PR DESCRIPTION
## Summary
- add QuestDefinition and QuestManager for side quests
- add LectureDefinition and LectureEvent for stat bonuses
- create example quests and lectures as ScriptableObject assets

## Testing
- `ls tests || echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_68582e73cf2c8328becaa0b3b08eb63c