### PR TITLE
Add Item Maker window for ConsumableItem assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ here you can run debug commands such as:
 Additional commands can be registered through the `DevConsole` component for
 future debugging needs.
 
+## Item Maker
+Use **Window → Sinclair Tools → Item Maker** to create or load a
+`ConsumableItem` asset. The window lets you edit the item's **Name**,
+**Description** and **Heal Amount** fields and save the changes back to the
+asset file.
+
 ## Placeholder Assets
 Most areas use cubes and basic shapes as temporary models. Create your own
 placeholders under the `Prefabs` folders or import free assets from the Unity

--- a/Sinclair-Tools/ItemMakerWindow.cs
+++ b/Sinclair-Tools/ItemMakerWindow.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using UnityEditor;
+
+public class ItemMakerWindow : EditorWindow
+{
+    private ConsumableItem item;
+
+    [MenuItem("Window/Sinclair Tools/Item Maker")]
+    public static void ShowWindow()
+    {
+        GetWindow<ItemMakerWindow>(false, "Item Maker");
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("Item Maker", EditorStyles.boldLabel);
+
+        item = (ConsumableItem)EditorGUILayout.ObjectField("Item", item, typeof(ConsumableItem), false);
+        if (item == null)
+        {
+            EditorGUILayout.HelpBox("Select or create a Consumable Item asset.", MessageType.Info);
+            if (GUILayout.Button("Create New"))
+            {
+                CreateNewItem();
+            }
+            if (GUILayout.Button("Load Item"))
+            {
+                LoadItem();
+            }
+            return;
+        }
+
+        EditorGUILayout.Space();
+        item.itemName = EditorGUILayout.TextField("Name", item.itemName);
+        item.description = EditorGUILayout.TextField("Description", item.description);
+        item.healAmount = EditorGUILayout.IntField("Heal Amount", item.healAmount);
+
+        if (GUILayout.Button("Save"))
+        {
+            SaveItem();
+        }
+
+        if (GUI.changed)
+        {
+            EditorUtility.SetDirty(item);
+        }
+    }
+
+    private void CreateNewItem()
+    {
+        item = ScriptableObject.CreateInstance<ConsumableItem>();
+        string path = EditorUtility.SaveFilePanelInProject("Save Consumable Item", "NewConsumableItem", "asset", "Specify where to save the asset.");
+        if (!string.IsNullOrEmpty(path))
+        {
+            AssetDatabase.CreateAsset(item, path);
+            AssetDatabase.SaveAssets();
+        }
+    }
+
+    private void SaveItem()
+    {
+        if (item != null)
+        {
+            EditorUtility.SetDirty(item);
+            AssetDatabase.SaveAssets();
+        }
+    }
+
+    private void LoadItem()
+    {
+        string path = EditorUtility.OpenFilePanel("Load Consumable Item", "Assets", "asset");
+        if (!string.IsNullOrEmpty(path))
+        {
+            path = FileUtil.GetProjectRelativePath(path);
+            item = AssetDatabase.LoadAssetAtPath<ConsumableItem>(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `ItemMakerWindow` editor window to manage `ConsumableItem` assets
- register the tool under **Window/Sinclair Tools/Item Maker**
- document how to use the new window

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858360eb07c8328af009b160378d841