### PR TITLE
Implement basic ability system

### DIFF
--- a/Character Foundation/Scripts/AbilityData.cs
+++ b/Character Foundation/Scripts/AbilityData.cs
@@ -7,4 +7,11 @@ public class AbilityData : ScriptableObject
     public string description;
     public int manaCost;
     public float cooldown;
+
+    /// <summary>
+    /// Applies this ability's effect from the user to the target.
+    /// Override in derived classes for custom behavior.
+    /// </summary>
+    public virtual void Apply(BattleCharacter user, BattleCharacter target) { }
 }
+

--- a/Character Foundation/Scripts/CharacterData.cs
+++ b/Character Foundation/Scripts/CharacterData.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "CharacterData", menuName = "Sinclair/Character Data")]
@@ -10,4 +11,8 @@ public class CharacterData : ScriptableObject
     public int strength;
     public int defense;
     public int agility;
+
+    // Abilities the character has learned
+    public List<AbilityData> abilities = new List<AbilityData>();
 }
+

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ missions.
 `LectureDefinition` assets describe stat bonuses awarded by `LectureEvent`
 components when a character attends a lecture.
 
+### AbilitySystem
+Handles casting character abilities during battle including MP costs and
+cooldowns. `DamageAbility` provides a simple example spell that deals damage to
+a target.
+
 ## Developer Console
 Press the **backquote (`) key** at runtime to open the developer console. From
 here you can run debug commands such as:

--- a/Scripts/GameSystems/AbilitySystem.cs
+++ b/Scripts/GameSystems/AbilitySystem.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Runtime system for handling ability costs, cooldowns and execution.
+/// </summary>
+public class AbilitySystem : MonoBehaviour
+{
+    private readonly Dictionary<BattleCharacter, Dictionary<AbilityData, float>> cooldowns = new();
+
+    public bool CanUseAbility(BattleCharacter user, AbilityData ability)
+    {
+        if (user == null || ability == null)
+            return false;
+        if (user.currentMP < ability.manaCost)
+            return false;
+        if (cooldowns.TryGetValue(user, out var dict) && dict.TryGetValue(ability, out float cd) && cd > 0f)
+            return false;
+        return true;
+    }
+
+    public void UseAbility(BattleCharacter user, BattleCharacter target, AbilityData ability)
+    {
+        if (!CanUseAbility(user, ability))
+            return;
+        user.currentMP -= ability.manaCost;
+        ability.Apply(user, target);
+        if (!cooldowns.TryGetValue(user, out var dict))
+            cooldowns[user] = dict = new Dictionary<AbilityData, float>();
+        dict[ability] = ability.cooldown;
+    }
+
+    private void Update()
+    {
+        float dt = Time.deltaTime;
+        foreach (var kv in cooldowns)
+        {
+            var abilities = new List<AbilityData>(kv.Value.Keys);
+            foreach (var ab in abilities)
+            {
+                kv.Value[ab] -= dt;
+                if (kv.Value[ab] <= 0f)
+                    kv.Value.Remove(ab);
+            }
+        }
+    }
+}
+

--- a/Scripts/GameSystems/BattleManager.cs
+++ b/Scripts/GameSystems/BattleManager.cs
@@ -12,12 +12,17 @@ public class BattleManager : MonoBehaviour
     public List<CharacterData> enemyCharacters = new List<CharacterData>();
     public InventoryManager inventory; // Tracks consumable items
     public ConsumableItem defaultItem;  // Item used for demo actions
+    public AbilitySystem abilitySystem; // Handles ability execution
 
     private readonly List<BattleCharacter> turnQueue = new List<BattleCharacter>();
     private int currentTurnIndex;
 
     private void Start()
     {
+        if (abilitySystem == null)
+        {
+            abilitySystem = GetComponent<AbilitySystem>();
+        }
         SetupBattle();
         StartCoroutine(BattleLoop());
     }
@@ -63,6 +68,11 @@ public class BattleManager : MonoBehaviour
         if (character.isPlayer && defaultItem != null && inventory != null && character.currentHP <= character.data.maxHP / 2 && inventory.GetQuantity(defaultItem) > 0)
         {
             UseItem(character, defaultItem, character);
+        }
+        else if (abilitySystem != null && character.data.abilities.Count > 0 && abilitySystem.CanUseAbility(character, character.data.abilities[0]))
+        {
+            AbilityData ability = character.data.abilities[0];
+            abilitySystem.UseAbility(character, target, ability);
         }
         else
         {
@@ -145,6 +155,7 @@ public class BattleCharacter
 {
     public CharacterData data;
     public int currentHP;
+    public int currentMP;
     public bool isPlayer;
 
     public BattleCharacter(CharacterData data, bool isPlayer)
@@ -152,5 +163,6 @@ public class BattleCharacter
         this.data = data;
         this.isPlayer = isPlayer;
         currentHP = data.maxHP;
+        currentMP = data.maxMP;
     }
 }

--- a/Scripts/GameSystems/DamageAbility.cs
+++ b/Scripts/GameSystems/DamageAbility.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple offensive ability that deals damage to a single target.
+/// </summary>
+[CreateAssetMenu(fileName = "DamageAbility", menuName = "Sinclair/Abilities/Damage")]
+public class DamageAbility : AbilityData
+{
+    public int damage = 5;
+
+    public override void Apply(BattleCharacter user, BattleCharacter target)
+    {
+        if (target == null)
+            return;
+        int finalDamage = Mathf.Max(1, damage + user.data.strength - target.data.defense);
+        if (!(target.isPlayer && DevConsole.IsGodMode))
+        {
+            target.currentHP -= finalDamage;
+        }
+        else
+        {
+            finalDamage = 0;
+        }
+        Debug.Log($"{user.data.characterName} casts {abilityName} on {target.data.characterName} for {finalDamage} damage!");
+    }
+}
+

--- a/Sinclair-Tools/CharacterDataEditorWindow.cs
+++ b/Sinclair-Tools/CharacterDataEditorWindow.cs
@@ -35,6 +35,17 @@ public class CharacterDataEditorWindow : EditorWindow
         data.defense = EditorGUILayout.IntField("Defense", data.defense);
         data.agility = EditorGUILayout.IntField("Agility", data.agility);
 
+        EditorGUILayout.LabelField("Abilities");
+        int count = Mathf.Max(0, EditorGUILayout.IntField("Size", data.abilities.Count));
+        while (count > data.abilities.Count)
+            data.abilities.Add(null);
+        while (count < data.abilities.Count)
+            data.abilities.RemoveAt(data.abilities.Count - 1);
+        for (int i = 0; i < data.abilities.Count; i++)
+        {
+            data.abilities[i] = (AbilityData)EditorGUILayout.ObjectField($"Element {i}", data.abilities[i], typeof(AbilityData), false);
+        }
+
         if (GUI.changed)
         {
             EditorUtility.SetDirty(data);


### PR DESCRIPTION
## Summary
- expand `CharacterData` to hold learned abilities
- update character editor to modify ability lists
- add an `AbilitySystem` component with cooldown and mana handling
- implement `DamageAbility` example spell
- allow `BattleManager` to cast abilities when possible
- document the new system in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858369577c483289d6cf90a00d09f3c