### PR TITLE
Extend DockIcon with action queue

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Assets/Scripts/GameSystems/BattleManager.cs" />
     <Compile Include="Assets/Scripts/GameSystems/BattleBarrier.cs" />
     <Compile Include="Assets/Scripts/GameSystems/AbilityData.cs" />
+    <Compile Include="Assets/Scripts/GameSystems/IDockAction.cs" />
+    <Compile Include="Assets/Scripts/GameSystems/BattleActionQueue.cs" />
     <Compile Include="Assets/Digger/Demo/FlyCamera.cs" />
     <Compile Include="Assets/UI/ObjectSpawner/DeveloperOptions.cs" />
     <Compile Include="Assets/Character Foundation/Scripts/CharacterData.cs" />

--- a/Scripts/GameSystems/BattleActionQueue.cs
+++ b/Scripts/GameSystems/BattleActionQueue.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Simple queue that executes dock actions sequentially.
+/// </summary>
+public class BattleActionQueue : MonoBehaviour
+{
+    public static BattleActionQueue Instance { get; private set; }
+
+    [Tooltip("Battle manager that processes queued actions.")]
+    public BattleManager battleManager;
+
+    private readonly Queue<IDockAction> queue = new();
+
+    private void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+    }
+
+    /// <summary>
+    /// Adds a dock action to the queue.
+    /// </summary>
+    public void QueueAction(IDockAction action)
+    {
+        if (action != null)
+            queue.Enqueue(action);
+    }
+
+    private void Update()
+    {
+        if (battleManager == null || queue.Count == 0)
+            return;
+
+        IDockAction action = queue.Dequeue();
+        action.Execute(battleManager);
+    }
+}

--- a/Scripts/GameSystems/IDockAction.cs
+++ b/Scripts/GameSystems/IDockAction.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents an executable action triggered from a dock icon.
+/// Abilities, items and menu shortcuts can implement this interface.
+/// </summary>
+public interface IDockAction
+{
+    /// <summary>
+    /// Executes the action using the provided battle manager.
+    /// </summary>
+    void Execute(BattleManager manager);
+}

--- a/UI/DockFolder.cs
+++ b/UI/DockFolder.cs
@@ -11,6 +11,17 @@ public class DockFolder : DockIcon, IDropHandler {
 
     protected override void Awake() {
         base.Awake();
+        if (subContainer == null)
+        {
+            GameObject child = new GameObject("SubDock", typeof(RectTransform), typeof(DockManager));
+            RectTransform rt = child.GetComponent<RectTransform>();
+            rt.SetParent(transform, false);
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            subContainer = rt;
+            child.SetActive(false);
+        }
         if (isPermanent) {
             isStatic = true;
         }
@@ -18,6 +29,7 @@ public class DockFolder : DockIcon, IDropHandler {
 
     public override void OnPointerClick(PointerEventData eventData) {
         ToggleFolder();
+        Execute();
     }
 
     public void ToggleFolder() {

--- a/UI/DockIcon.cs
+++ b/UI/DockIcon.cs
@@ -19,6 +19,11 @@ public class DockIcon : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDrag
     // Used internally to differentiate an original icon from a spawned copy.
     private bool isClone = false;
 
+    [Header("Action")]
+    [Tooltip("Action executed when this icon is clicked.")]
+    public ScriptableObject actionAsset;
+    protected IDockAction dockAction;
+
     [Header("Drag Settings")]
     public Canvas parentCanvas; // If not set, auto-finds the parent Canvas.
     protected RectTransform rectTransform;
@@ -46,6 +51,7 @@ public class DockIcon : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDrag
             parentCanvas = GetComponentInParent<Canvas>();
         originalParent = transform.parent;
         initialScale = rectTransform.localScale;
+        dockAction = actionAsset as IDockAction;
     }
 
     protected virtual void Update()
@@ -173,6 +179,7 @@ public class DockIcon : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDrag
 
     public virtual void OnPointerClick(PointerEventData eventData)
     {
+        Execute();
         // If this is not a folder and not currently animating, activate ability.
         if (GetComponent<DockFolder>() == null && !isAbilityActive)
             StartCoroutine(AbilityActivationRoutine());
@@ -205,5 +212,16 @@ public class DockIcon : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDrag
             yield return null;
         }
         isAbilityActive = false;
+    }
+
+    /// <summary>
+    /// Queues this icon's action for execution.
+    /// </summary>
+    public virtual void Execute()
+    {
+        if (dockAction != null && BattleActionQueue.Instance != null)
+        {
+            BattleActionQueue.Instance.QueueAction(dockAction);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `IDockAction` interface
- add `BattleActionQueue` system to run dock actions
- extend `DockIcon` with an action reference and `Execute`
- allow `DockFolder` to spawn sub‑containers and queue actions when clicked
- register new files in project build

## Testing
- `dotnet build Assembly-CSharp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586b2a19448328ace90efc35729d7a