### PR TITLE
Add simple target selection system

### DIFF
--- a/Scripts/Targeting/TargetManager.cs
+++ b/Scripts/Targeting/TargetManager.cs
@@ -1,0 +1,67 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Handles selecting <see cref="Targetable"/> objects via mouse clicks.
+/// Raycasts from the main camera and highlights the currently selected target.
+/// </summary>
+public class TargetManager : MonoBehaviour
+{
+    public event Action<Targetable> TargetSelected;
+    public event Action<Targetable> TargetDeselected;
+
+    public float rayDistance = 100f;
+    public LayerMask rayLayers = Physics.DefaultRaycastLayers;
+
+    private Targetable currentTarget;
+
+    /// <summary>
+    /// Currently selected target, or null if none.
+    /// </summary>
+    public Targetable CurrentTarget => currentTarget;
+
+    private void Update()
+    {
+        if (Input.GetMouseButtonDown(0))
+        {
+            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+            if (Physics.Raycast(ray, out RaycastHit hit, rayDistance, rayLayers))
+            {
+                Targetable t = hit.collider.GetComponentInParent<Targetable>();
+                if (t != null && (t.CompareTag("Enemy") || t.CompareTag("NPC")))
+                {
+                    Select(t);
+                }
+                else
+                {
+                    Select(null);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets the active target and handles highlight logic.
+    /// </summary>
+    public void Select(Targetable target)
+    {
+        if (currentTarget == target)
+        {
+            return;
+        }
+
+        if (currentTarget != null)
+        {
+            currentTarget.Highlight(false);
+            TargetDeselected?.Invoke(currentTarget);
+        }
+
+        currentTarget = target;
+
+        if (currentTarget != null)
+        {
+            currentTarget.Highlight(true);
+            TargetSelected?.Invoke(currentTarget);
+        }
+    }
+}

--- a/Scripts/Targeting/Targetable.cs
+++ b/Scripts/Targeting/Targetable.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// Component allowing an object to be targeted by <see cref="TargetManager"/>.
+/// Tracks basic health and manages a highlight effect when selected.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class Targetable : MonoBehaviour
+{
+    [Tooltip("Name used when displaying this target.")]
+    public string displayName;
+
+    [Tooltip("Maximum hit points for this target.")]
+    public int maxHP = 100;
+    public int currentHP = 100;
+
+    [Tooltip("Optional component toggled when the target is highlighted.")]
+    public Behaviour highlight;
+
+    private void Awake()
+    {
+        currentHP = Mathf.Clamp(currentHP, 0, maxHP);
+        if (highlight != null)
+        {
+            highlight.enabled = false;
+        }
+    }
+
+    /// <summary>
+    /// Enables or disables the highlight effect.
+    /// </summary>
+    public void Highlight(bool enable)
+    {
+        if (highlight != null)
+        {
+            highlight.enabled = enable;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Targetable` component for targetable objects
- add `TargetManager` that raycasts and highlights targets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68593efbda008328ba324885b3b87894