### PR TITLE
Add TargetInfo UI

### DIFF
--- a/Scripts/Targeting/TargetInfoUI.cs
+++ b/Scripts/Targeting/TargetInfoUI.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Displays information about the currently selected <see cref="Targetable"/>.
+/// Listens to <see cref="TargetManager"/> events and updates UI elements.
+/// </summary>
+public class TargetInfoUI : MonoBehaviour
+{
+    [Tooltip("Manager providing target selection events.")]
+    public TargetManager targetManager;
+    [Tooltip("Text element used to display the target name.")]
+    public TextMeshProUGUI nameText;
+    [Tooltip("Image fill used to display health remaining.")]
+    public Image healthBar;
+
+    private Targetable current;
+
+    private void Awake()
+    {
+        if (targetManager == null)
+        {
+            targetManager = FindObjectOfType<TargetManager>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (targetManager != null)
+        {
+            targetManager.TargetSelected += OnTargetSelected;
+            targetManager.TargetDeselected += OnTargetDeselected;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (targetManager != null)
+        {
+            targetManager.TargetSelected -= OnTargetSelected;
+            targetManager.TargetDeselected -= OnTargetDeselected;
+        }
+    }
+
+    private void Update()
+    {
+        if (current != null && healthBar != null)
+        {
+            healthBar.fillAmount = current.maxHP > 0 ? (float)current.currentHP / current.maxHP : 0f;
+        }
+    }
+
+    private void OnTargetSelected(Targetable t)
+    {
+        current = t;
+        if (nameText != null)
+        {
+            nameText.text = t != null ? t.displayName : string.Empty;
+        }
+        gameObject.SetActive(t != null);
+    }
+
+    private void OnTargetDeselected(Targetable t)
+    {
+        if (current == t)
+        {
+            current = null;
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Scripts/Targeting/TargetInfoUI.cs.meta
+++ b/Scripts/Targeting/TargetInfoUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d874b0f513574853b65b68634eb1b19c

--- a/UI/TargetInfoPanel.prefab
+++ b/UI/TargetInfoPanel.prefab
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: TargetInfoPanel
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+--- !u!224 &2
+RectTransform:
+  m_GameObject: {fileID: 1}
+--- !u!114 &3
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 11500000, guid: d874b0f513574853b65b68634eb1b19c, type: 3}
+  nameText: {fileID: 7}
+  healthBar: {fileID: 10}
+--- !u!222 &4
+CanvasRenderer:
+  m_GameObject: {fileID: 1}
+--- !u!1 &5
+GameObject:
+  m_Name: Name
+  m_Component:
+  - component: {fileID: 6}
+  - component: {fileID: 7}
+--- !u!224 &6
+RectTransform:
+  m_GameObject: {fileID: 5}
+  m_Father: {fileID: 2}
+--- !u!114 &7
+MonoBehaviour:
+  m_GameObject: {fileID: 5}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_text: Name
+--- !u!1 &8
+GameObject:
+  m_Name: HealthBar
+  m_Component:
+  - component: {fileID: 9}
+  - component: {fileID: 10}
+--- !u!224 &9
+RectTransform:
+  m_GameObject: {fileID: 8}
+  m_Father: {fileID: 2}
+--- !u!114 &10
+MonoBehaviour:
+  m_GameObject: {fileID: 8}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}

--- a/UI/TargetInfoPanel.prefab.meta
+++ b/UI/TargetInfoPanel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aea9ecab3535491790d0bf00519cc94c
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add TargetInfoUI script that hooks into TargetManager and updates UI
- create TargetInfoPanel prefab with TextMeshPro name and health bar

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593fe20a0c8328ad528180a1ae687d