### PR TITLE
Allow configuring TargetManager raycast camera

### DIFF
--- a/Scripts/Targeting/TargetManager.cs
+++ b/Scripts/Targeting/TargetManager.cs
@@ -12,6 +12,7 @@ public class TargetManager : MonoBehaviour
     public event Action<Targetable> TargetDeselected;
 
     public float rayDistance = 100f;
+    public Camera raycastCamera;
     public LayerMask rayLayers = Physics.DefaultRaycastLayers;
 
     private Targetable currentTarget;
@@ -25,6 +26,10 @@ public class TargetManager : MonoBehaviour
     private void Awake()
     {
         input = new InputSystem_Actions();
+        if (raycastCamera == null)
+        {
+            raycastCamera = Camera.main;
+        }
     }
 
     private void OnEnable()
@@ -44,7 +49,7 @@ public class TargetManager : MonoBehaviour
         if (!ctx.performed) return;
 
         Vector2 pos = Pointer.current != null ? Pointer.current.position.ReadValue() : Vector2.zero;
-        Ray ray = Camera.main.ScreenPointToRay(pos);
+        Ray ray = raycastCamera.ScreenPointToRay(pos);
         if (Physics.Raycast(ray, out RaycastHit hit, rayDistance, rayLayers))
         {
             Targetable t = hit.collider.GetComponentInParent<Targetable>();


### PR DESCRIPTION
## Summary
- add customizable camera reference in `TargetManager`
- default to `Camera.main` if no camera assigned
- raycast using the configured camera

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859464764ec8328b8e88a8fde7477e3