### PR TITLE
Add health change event and UI handling

### DIFF
--- a/Scripts/GameSystems/BattleManager.cs
+++ b/Scripts/GameSystems/BattleManager.cs
@@ -81,7 +81,7 @@ public class BattleManager : MonoBehaviour
 
             if (!(target.isPlayer && DevConsole.IsGodMode))
             {
-                target.currentHP -= damage;
+                target.ChangeHP(-damage);
             }
             else
             {
@@ -164,5 +164,13 @@ public class BattleCharacter
         this.isPlayer = isPlayer;
         currentHP = data.maxHP;
         currentMP = data.maxMP;
+    }
+
+    /// <summary>
+    /// Adjusts HP by the given amount while clamping between 0 and max.
+    /// </summary>
+    public void ChangeHP(int amount)
+    {
+        currentHP = Mathf.Clamp(currentHP + amount, 0, data.maxHP);
     }
 }

--- a/Scripts/GameSystems/DamageAbility.cs
+++ b/Scripts/GameSystems/DamageAbility.cs
@@ -15,7 +15,7 @@ public class DamageAbility : AbilityData
         int finalDamage = Mathf.Max(1, damage + user.data.strength - target.data.defense);
         if (!(target.isPlayer && DevConsole.IsGodMode))
         {
-            target.currentHP -= finalDamage;
+            target.ChangeHP(-finalDamage);
         }
         else
         {

--- a/Scripts/Items/ConsumableItem.cs
+++ b/Scripts/Items/ConsumableItem.cs
@@ -16,7 +16,7 @@ public class ConsumableItem : ScriptableObject
     {
         if (target != null)
         {
-            target.currentHP = Mathf.Min(target.data.maxHP, target.currentHP + healAmount);
+            target.ChangeHP(healAmount);
             Debug.Log($"{itemName} heals {target.data.characterName} for {healAmount} HP.");
         }
     }

--- a/Scripts/Targeting/TargetInfoUI.cs
+++ b/Scripts/Targeting/TargetInfoUI.cs
@@ -43,17 +43,28 @@ public class TargetInfoUI : MonoBehaviour
         }
     }
 
-    private void Update()
+
+    private void OnHealthChanged(int hp)
     {
         if (current != null && healthBar != null)
         {
-            healthBar.fillAmount = current.maxHP > 0 ? (float)current.currentHP / current.maxHP : 0f;
+            healthBar.fillAmount = current.maxHP > 0 ? (float)hp / current.maxHP : 0f;
         }
     }
 
     private void OnTargetSelected(Targetable t)
     {
+        if (current != null)
+        {
+            current.HealthChanged -= OnHealthChanged;
+        }
+
         current = t;
+        if (current != null)
+        {
+            current.HealthChanged += OnHealthChanged;
+            OnHealthChanged(current.currentHP);
+        }
         if (nameText != null)
         {
             nameText.text = t != null ? t.displayName : string.Empty;
@@ -65,6 +76,7 @@ public class TargetInfoUI : MonoBehaviour
     {
         if (current == t)
         {
+            current.HealthChanged -= OnHealthChanged;
             current = null;
             gameObject.SetActive(false);
         }

--- a/Scripts/Targeting/Targetable.cs
+++ b/Scripts/Targeting/Targetable.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 /// <summary>
@@ -13,6 +14,12 @@ public class Targetable : MonoBehaviour
     [Tooltip("Maximum hit points for this target.")]
     public int maxHP = 100;
     public int currentHP = 100;
+
+    /// <summary>
+    /// Fired whenever the current HP value changes.
+    /// Provides the new HP value as a parameter.
+    /// </summary>
+    public event Action<int> HealthChanged;
 
     [Tooltip("Optional component toggled when the target is highlighted.")]
     public Behaviour highlight;
@@ -34,6 +41,19 @@ public class Targetable : MonoBehaviour
         if (highlight != null)
         {
             highlight.enabled = enable;
+        }
+    }
+
+    /// <summary>
+    /// Adjusts this target's HP and invokes <see cref="HealthChanged"/>.
+    /// </summary>
+    public void ChangeHP(int amount)
+    {
+        int old = currentHP;
+        currentHP = Mathf.Clamp(currentHP + amount, 0, maxHP);
+        if (currentHP != old)
+        {
+            HealthChanged?.Invoke(currentHP);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `HealthChanged` event and `ChangeHP` method on `Targetable`
- use `ChangeHP` for damage/consumable logic
- update `BattleCharacter` with a `ChangeHP` helper
- subscribe UI to `HealthChanged` instead of polling

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594827c9908328bcd854e4c9072ca1