### PR TITLE
Remove tag checks in TargetManager

### DIFF
--- a/Scripts/Targeting/TargetManager.cs
+++ b/Scripts/Targeting/TargetManager.cs
@@ -53,7 +53,7 @@ public class TargetManager : MonoBehaviour
         if (Physics.Raycast(ray, out RaycastHit hit, rayDistance, rayLayers))
         {
             Targetable t = hit.collider.GetComponentInParent<Targetable>();
-            if (t != null && (t.CompareTag("Enemy") || t.CompareTag("NPC")))
+            if (t != null && t.isTargetable)
             {
                 Select(t);
             }

--- a/Scripts/Targeting/Targetable.cs
+++ b/Scripts/Targeting/Targetable.cs
@@ -9,6 +9,8 @@ using UnityEngine;
 [RequireComponent(typeof(Collider))]
 public class Targetable : MonoBehaviour
 {
+    [Tooltip("Whether this object can currently be selected as a target.")]
+    public bool isTargetable = true;
     [Tooltip("Name used when displaying this target.")]
     public string displayName;
 


### PR DESCRIPTION
## Summary
- let TargetManager use `isTargetable` instead of tag checks
- allow Targetable objects to be toggled via new `isTargetable` flag

## Testing
- `dotnet build Assembly-CSharp.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594aaa25248328b9b5c85e4b9bd67b