### PR TITLE
Add continuous hold movement

### DIFF
--- a/InputSystem_Actions.cs
+++ b/InputSystem_Actions.cs
@@ -107,6 +107,15 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""HoldMove"",
+                    ""type"": ""Button"",
+                    ""id"": ""ad18ca11-0421-450e-8c0f-3a2789fd7d45"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -393,6 +402,28 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": ""XR"",
                     ""action"": ""Sprint"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""4d1fe1ef-267b-42fe-a33b-4d36665c9739"",
+                    ""path"": ""<Mouse>/rightButton"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""HoldMove"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""a6788617-5ed9-407a-906d-19079593d393"",
+                    ""path"": ""<Gamepad>/leftStick"",
+                    ""interactions"": ""Press"",
+                    ""processors"": """",
+                    ""groups"": ""Gamepad"",
+                    ""action"": ""HoldMove"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -1110,6 +1141,7 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         m_Player_Previous = m_Player.FindAction("Previous", throwIfNotFound: true);
         m_Player_Next = m_Player.FindAction("Next", throwIfNotFound: true);
         m_Player_Sprint = m_Player.FindAction("Sprint", throwIfNotFound: true);
+        m_Player_HoldMove = m_Player.FindAction("HoldMove", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
         m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
@@ -1198,6 +1230,7 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Previous;
     private readonly InputAction m_Player_Next;
     private readonly InputAction m_Player_Sprint;
+    private readonly InputAction m_Player_HoldMove;
     public struct PlayerActions
     {
         private @InputSystem_Actions m_Wrapper;
@@ -1211,6 +1244,7 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         public InputAction @Previous => m_Wrapper.m_Player_Previous;
         public InputAction @Next => m_Wrapper.m_Player_Next;
         public InputAction @Sprint => m_Wrapper.m_Player_Sprint;
+        public InputAction @HoldMove => m_Wrapper.m_Player_HoldMove;
         public InputActionMap Get() { return m_Wrapper.m_Player; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -1247,6 +1281,9 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
             @Sprint.started += instance.OnSprint;
             @Sprint.performed += instance.OnSprint;
             @Sprint.canceled += instance.OnSprint;
+            @HoldMove.started += instance.OnHoldMove;
+            @HoldMove.performed += instance.OnHoldMove;
+            @HoldMove.canceled += instance.OnHoldMove;
         }
 
         private void UnregisterCallbacks(IPlayerActions instance)
@@ -1278,6 +1315,9 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
             @Sprint.started -= instance.OnSprint;
             @Sprint.performed -= instance.OnSprint;
             @Sprint.canceled -= instance.OnSprint;
+            @HoldMove.started -= instance.OnHoldMove;
+            @HoldMove.performed -= instance.OnHoldMove;
+            @HoldMove.canceled -= instance.OnHoldMove;
         }
 
         public void RemoveCallbacks(IPlayerActions instance)
@@ -1469,6 +1509,7 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         void OnPrevious(InputAction.CallbackContext context);
         void OnNext(InputAction.CallbackContext context);
         void OnSprint(InputAction.CallbackContext context);
+        void OnHoldMove(InputAction.CallbackContext context);
     }
     public interface IUIActions
     {

--- a/InputSystem_Actions.inputactions
+++ b/InputSystem_Actions.inputactions
@@ -85,6 +85,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "HoldMove",
+                    "type": "Button",
+                    "id": "ad18ca11-0421-450e-8c0f-3a2789fd7d45",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -371,6 +380,28 @@
                     "processors": "",
                     "groups": "XR",
                     "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4d1fe1ef-267b-42fe-a33b-4d36665c9739",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "HoldMove",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a6788617-5ed9-407a-906d-19079593d393",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "HoldMove",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Scripts/Character/PointClickMovement.cs
+++ b/Scripts/Character/PointClickMovement.cs
@@ -15,10 +15,13 @@ public class PointClickMovement : MonoBehaviour
     public float effectDuration = 1f; // Lifetime of the spawned effect
     [Tooltip("How close the agent should get to Targetable objects.")]
     public float targetRange = 1f;
+    [Tooltip("If true, holding the input will continuously update the destination.")]
+    public bool continuousMovement;
 
     private NavMeshAgent agent;
     private InputSystem_Actions input;
     private InputAction moveClick;
+    private InputAction holdMove;
 
     private void Awake()
     {
@@ -35,6 +38,7 @@ public class PointClickMovement : MonoBehaviour
             moveClick = input.UI.RightClick;
         }
         moveClick.performed += OnMoveClick;
+        holdMove = input.asset.FindAction("HoldMove", false);
     }
 
     private void OnDisable()
@@ -46,10 +50,22 @@ public class PointClickMovement : MonoBehaviour
         input.Disable();
     }
 
+    private void Update()
+    {
+        if (continuousMovement && holdMove != null && holdMove.IsPressed())
+        {
+            MoveAgentToPointer();
+        }
+    }
+
     private void OnMoveClick(InputAction.CallbackContext ctx)
     {
         if (!ctx.performed) return;
+        MoveAgentToPointer();
+    }
 
+    private void MoveAgentToPointer()
+    {
         Vector2 pos = Pointer.current != null ? Pointer.current.position.ReadValue() : Vector2.zero;
         Ray ray = Camera.main.ScreenPointToRay(pos);
         if (Physics.Raycast(ray, out RaycastHit hit))


### PR DESCRIPTION
## Summary
- add optional continuous movement to PointClickMovement
- create HoldMove input action bound to mouse hold or gamepad stick
- generate bindings in action asset and code

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594b41b6188328aec07e0d5378e7b9